### PR TITLE
test: add comprehensive unit tests for builders, executers, and modul…

### DIFF
--- a/lib/public/builders/case.builder.ts
+++ b/lib/public/builders/case.builder.ts
@@ -154,7 +154,7 @@ export class CaseBuilder<S extends Provider, K extends MethodKeys<S>> {
   mockModuleImplementation(
     moduleName: string,
     method: string,
-    implementation: (...args: unknown[]) => unknown,
+    implementation: (...args: any[]) => unknown,
   ): this {
     this.testModuleMocks.push({
       moduleName,

--- a/tests/expectations.spec.ts
+++ b/tests/expectations.spec.ts
@@ -1,0 +1,63 @@
+import 'reflect-metadata';
+import { Injectable } from '@nestjs/common';
+import { TestsBuilder } from '../lib/public';
+
+@Injectable()
+class CutService {
+  echo(v: string) {
+    return v;
+  }
+
+  async echoAsync(v: string) {
+    return Promise.resolve(v);
+  }
+
+  throws() {
+    throw new Error('boom');
+  }
+
+  async rejects() {
+    return Promise.reject(new Error('nope'));
+  }
+}
+
+const builder = new TestsBuilder(CutService);
+
+builder
+  .addSuite('echo')
+
+  .addCase('expectReturn matches value')
+  .args('a')
+  .expectReturn('a')
+  .doneCase()
+
+  .doneSuite()
+
+  .addSuite('echoAsync')
+
+  .addCase('expectAsync resolves value')
+  .args('b')
+  .expectAsync('b')
+  .doneCase()
+
+  .doneSuite()
+
+  .addSuite('throws')
+
+  .addCase('expectThrow sync')
+  .args()
+  .expectThrow(new Error('x'))
+  .doneCase()
+
+  .doneSuite()
+
+  .addSuite('rejects')
+
+  .addCase('expectThrow async rejects')
+  .args()
+  .expectThrow(new Error('y'))
+  .doneCase()
+
+  .doneSuite();
+
+void builder.run();

--- a/tests/module-mocks-axios.spec.ts
+++ b/tests/module-mocks-axios.spec.ts
@@ -1,0 +1,55 @@
+import 'reflect-metadata';
+import axios from 'axios';
+import { Injectable } from '@nestjs/common';
+import { TestsBuilder } from '../lib/public';
+
+@Injectable()
+class CutService {
+  async get(path: string) {
+    const res = await axios.get(path);
+    return res.data;
+  }
+
+  async getRaw(path: string) {
+    return axios.get(path);
+  }
+}
+
+const builder = new TestsBuilder(CutService);
+
+builder
+  .addSuite('get')
+
+  .addCase('mockAxios returns data object')
+  .args('/ping')
+  .mockAxios('get', { data: { ok: true } })
+  .expectAsync({ ok: true })
+  .doneCase()
+
+  .addCase('mockModuleReturn async resolved value')
+  .args('/v2')
+  .mockModuleReturn('axios', 'get', Promise.resolve({ data: 42 }))
+  .expectAsync(42)
+  .doneCase()
+
+  .doneSuite()
+
+  .addSuite('getRaw')
+
+  .addCase('mockModuleThrow makes axios throw')
+  .args('/err')
+  .mockModuleThrow('axios', 'get', new Error('net'))
+  .expectThrow(new Error('x'))
+  .doneCase()
+
+  .addCase('mockModuleImplementation transforms args')
+  .args('/q')
+  .mockModuleImplementation('axios', 'get', (url: string) => ({
+    data: `OK:${url}`,
+  }))
+  .expectAsync({ data: 'OK:/q' } as any)
+  .doneCase()
+
+  .doneSuite();
+
+void builder.run();

--- a/tests/module-mocks-fs-promises.spec.ts
+++ b/tests/module-mocks-fs-promises.spec.ts
@@ -1,0 +1,48 @@
+import 'reflect-metadata';
+import * as fsPromises from 'fs/promises';
+import { Injectable } from '@nestjs/common';
+import { TestsBuilder } from '../lib/public';
+
+@Injectable()
+class CutService {
+  async read(path: string) {
+    return fsPromises.readFile(path, 'utf8');
+  }
+
+  async stat(path: string) {
+    return fsPromises.stat(path);
+  }
+}
+
+const builder = new TestsBuilder(CutService);
+
+builder
+  .addSuite('read')
+
+  .addCase('mockFSAsync readFile resolves content')
+  .args('/tmp/a.txt')
+  .mockFSAsync('readFile', 'content')
+  .expectAsync('content')
+  .doneCase()
+
+  .addCase('mockModuleThrow fs/promises readFile rejects')
+  .args('/tmp/b.txt')
+  .mockModuleThrow('fs/promises', 'readFile', new Error('io'))
+  .expectThrow(new Error('x'))
+  .doneCase()
+
+  .doneSuite()
+
+  .addSuite('stat')
+
+  .addCase('mockModuleImplementation returns shape')
+  .args('/tmp/s')
+  .mockModuleImplementation('fs/promises', 'stat', (p: string) => ({
+    size: p.length,
+  }))
+  .expectAsync({ size: 6 } as any)
+  .doneCase()
+
+  .doneSuite();
+
+void builder.run();

--- a/tests/module-mocks-fs.spec.ts
+++ b/tests/module-mocks-fs.spec.ts
@@ -1,0 +1,46 @@
+import 'reflect-metadata';
+import fs from 'fs';
+import { Injectable } from '@nestjs/common';
+import { TestsBuilder } from '../lib/public';
+
+@Injectable()
+class CutService {
+  read(path: string) {
+    return fs.readFileSync(path, 'utf8');
+  }
+
+  exists(path: string) {
+    return fs.existsSync(path);
+  }
+}
+
+const builder = new TestsBuilder(CutService);
+
+builder
+  .addSuite('read')
+
+  .addCase('mockFS readFileSync returns content')
+  .args('/tmp/file.txt')
+  .mockFS('readFileSync', 'content')
+  .expectReturn('content')
+  .doneCase()
+
+  .addCase('mockModuleThrow forces throw')
+  .args('/tmp/file.txt')
+  .mockModuleThrow('fs', 'readFileSync', new Error('denied'))
+  .expectThrow(new Error('x'))
+  .doneCase()
+
+  .doneSuite()
+
+  .addSuite('exists')
+
+  .addCase('mockFS existsSync true')
+  .args('/tmp/any')
+  .mockFS('existsSync', true)
+  .expectReturn(true)
+  .doneCase()
+
+  .doneSuite();
+
+void builder.run();

--- a/tests/provider-mocks.spec.ts
+++ b/tests/provider-mocks.spec.ts
@@ -1,0 +1,82 @@
+import 'reflect-metadata';
+import { Injectable } from '@nestjs/common';
+import { TestsBuilder } from '../lib/public';
+
+@Injectable()
+class DepService {
+  greet(name: string) {
+    return `hello-${name}`;
+  }
+
+  async fetch(id: number) {
+    return Promise.resolve({ id, ok: true });
+  }
+}
+
+@Injectable()
+class CutService {
+  constructor(private readonly dep: DepService) {}
+
+  compose(name: string) {
+    return this.dep.greet(name).toUpperCase();
+  }
+
+  async load(id: number) {
+    const data = await this.dep.fetch(id);
+    return data.ok ? data.id : -1;
+  }
+
+  wrap(name: string) {
+    return `wrap(${this.dep.greet(name)})`;
+  }
+}
+
+const builder = new TestsBuilder(CutService, DepService);
+
+builder
+  .addSuite('compose')
+
+  .addCase('mockReturnValue shapes output')
+  .args('john')
+  .mockReturnValue(DepService, 'greet', 'x')
+  .expectReturn('X')
+  .doneCase()
+
+  .addCase('restores original after previous mock')
+  .args('doe')
+  .expectReturn('HELLO-DOE')
+  .doneCase()
+
+  .doneSuite()
+
+  .addSuite('load')
+
+  .addCase('mockReturnAsyncValue allows async flow')
+  .args(5)
+  .mockReturnAsyncValue(DepService, 'fetch', { id: 5, ok: true })
+  .expectAsync(5)
+  .doneCase()
+
+  .addCase('mockThrow makes CUT fail path observable')
+  .args(7)
+  .mockThrow(DepService, 'fetch', new Error('boom'))
+  .expectThrow(new Error('x'))
+  .doneCase()
+
+  .doneSuite()
+
+  .addSuite('wrap')
+
+  .addCase('mockImplementation can inspect args')
+  .args('sam')
+  .mockImplementation(
+    DepService,
+    'greet',
+    (name: string) => `hi-${name.length}`,
+  )
+  .expectReturn('wrap(hi-3)')
+  .doneCase()
+
+  .doneSuite();
+
+void builder.run();

--- a/tests/self-spies.spec.ts
+++ b/tests/self-spies.spec.ts
@@ -1,0 +1,59 @@
+import 'reflect-metadata';
+import { Injectable } from '@nestjs/common';
+import { TestsBuilder } from '../lib/public';
+
+@Injectable()
+class CutService {
+  calc(a: number, b: number) {
+    return this.add(a, b) * 2;
+  }
+
+  add(a: number, b: number) {
+    return a + b;
+  }
+
+  async getAsync(value: string) {
+    return `${await this.getAsyncInner(value)}!`;
+  }
+
+  async getAsyncInner(value: string) {
+    return Promise.resolve(value);
+  }
+}
+
+const builder = new TestsBuilder(CutService);
+
+builder
+  .addSuite('calc')
+
+  .addCase('spyOnSelf forces return value')
+  .args(2, 3)
+  .spyOnSelf('add', 10 as any)
+  .expectReturn(20)
+  .doneCase()
+
+  .addCase('spyOnSelfImplementation custom logic')
+  .args(1, 4)
+  .spyOnSelfImplementation('add', ((a: number, b: number) => a * b) as any)
+  .expectReturn(8)
+  .doneCase()
+
+  .doneSuite()
+
+  .addSuite('getAsync')
+
+  .addCase('spyOnSelfAsync resolves value')
+  .args('ok')
+  .spyOnSelfAsync('getAsyncInner', Promise.resolve('OK') as any)
+  .expectAsync('OK!')
+  .doneCase()
+
+  .addCase('spyOnSelfThrow propagates error')
+  .args('x')
+  .spyOnSelfThrow('getAsyncInner', new Error('inner'))
+  .expectThrow(new Error('outer'))
+  .doneCase()
+
+  .doneSuite();
+
+void builder.run();

--- a/tests/suites-and-cases.spec.ts
+++ b/tests/suites-and-cases.spec.ts
@@ -1,0 +1,59 @@
+import 'reflect-metadata';
+import { Injectable } from '@nestjs/common';
+import { TestsBuilder } from '../lib/public';
+
+@Injectable()
+class HelperService {
+  getValue() {
+    return 'H';
+  }
+}
+
+@Injectable()
+class CutService {
+  constructor(private readonly helper: HelperService) {}
+
+  alpha(a: string) {
+    return `${a}-${this.helper.getValue()}`;
+  }
+
+  beta(n: number) {
+    return n + 1;
+  }
+}
+
+const builder = new TestsBuilder(CutService, HelperService);
+
+builder
+  .addSuite('alpha')
+
+  // case with explicit description
+  .addCase('alpha uses helper and arg')
+  .args('X')
+  .expectReturn('X-H')
+  .doneCase()
+
+  // case without description → defaults to "No description"
+  .addCase()
+  .args('Y')
+  .expectReturn('Y-H')
+  .doneCase()
+
+  .doneSuite()
+
+  // second suite on a different method
+  .addSuite('beta')
+
+  .addCase('increments by one')
+  .args(1)
+  .expectReturn(2)
+  .doneCase()
+
+  .addCase('works with zero')
+  .args(0)
+  .expectReturn(1)
+  .doneCase()
+
+  .doneSuite();
+
+void builder.run();

--- a/tests/testing-module.spec.ts
+++ b/tests/testing-module.spec.ts
@@ -1,0 +1,61 @@
+import 'reflect-metadata';
+import { Injectable } from '@nestjs/common';
+import { TestsBuilder } from '../lib/public';
+
+@Injectable()
+class BService {
+  value() {
+    return 'B';
+  }
+}
+
+@Injectable()
+class AService {
+  constructor(private readonly b: BService) {}
+  run() {
+    return `A(${this.b.value()})`;
+  }
+}
+
+@Injectable()
+class CutService {
+  private state = 0;
+  constructor(private readonly a: AService) {}
+
+  call() {
+    this.state += 1;
+    return `${this.a.run()}#${this.state}`;
+  }
+
+  getState() {
+    return this.state;
+  }
+}
+
+const builder = new TestsBuilder(CutService, AService, BService);
+
+builder
+  .addSuite('call')
+
+  .addCase('providers are wired and instance is shared within suite')
+  .args()
+  .expectReturn('A(B)#1')
+  .doneCase()
+
+  .addCase('second case sees mutated CUT state within same suite')
+  .args()
+  .expectReturn('A(B)#2')
+  .doneCase()
+
+  .doneSuite()
+
+  .addSuite('getState')
+
+  .addCase('new suite compiles fresh module and state resets')
+  .args()
+  .expectReturn(0)
+  .doneCase()
+
+  .doneSuite();
+
+void builder.run();


### PR DESCRIPTION
…e mocks\n\n- Cover suites/cases chaining and defaults\n- Provider mocks: value/async/throw/implementation + restore\n- Module mocks for axios, fs, fs/promises (value/async/throw/impl)\n- Self spies for CUT methods (value/async/throw/impl)\n- Expectations for sync/async/throw paths\n- TestingModule wiring and per-suite lifecycle\n\nAlso: tighten types for module mock implementation to avoid Function