### PR TITLE
Service logger mocking

### DIFF
--- a/lib/private/utils/auto-mock-resolver.ts
+++ b/lib/private/utils/auto-mock-resolver.ts
@@ -38,8 +38,28 @@ export class AutoMockResolver {
   private static getMethodNames<T extends Provider>(
     provider: T,
   ): MethodKeys<T>[] {
-    return Object.getOwnPropertyNames(provider.prototype).filter(
-      methodName => typeof provider.prototype[methodName] === 'function',
-    ) as MethodKeys<T>[];
+    const methodNames = new Set<string>();
+    let currentPrototype = provider.prototype;
+
+    while (currentPrototype && currentPrototype !== Object.prototype) {
+      for (const methodName of Object.getOwnPropertyNames(currentPrototype)) {
+        if (methodName === 'constructor') {
+          continue;
+        }
+
+        const descriptor = Object.getOwnPropertyDescriptor(
+          currentPrototype,
+          methodName,
+        );
+
+        if (descriptor && typeof descriptor.value === 'function') {
+          methodNames.add(methodName);
+        }
+      }
+
+      currentPrototype = Object.getPrototypeOf(currentPrototype);
+    }
+
+    return Array.from(methodNames) as MethodKeys<T>[];
   }
 }

--- a/tests/logger-mocking.spec.ts
+++ b/tests/logger-mocking.spec.ts
@@ -1,0 +1,35 @@
+import 'reflect-metadata';
+import { Injectable } from '@nestjs/common';
+import { TestsBuilder } from '../lib/public';
+
+class BaseLogger {
+  log(message: string): void {
+    void message;
+  }
+}
+
+@Injectable()
+class AppLogger extends BaseLogger {}
+
+@Injectable()
+class LoggingService {
+  constructor(private readonly logger: AppLogger) {}
+
+  doWork() {
+    this.logger.log('work');
+    return 'done';
+  }
+}
+
+const builder = new TestsBuilder(LoggingService, AppLogger);
+
+builder
+  .addSuite('doWork')
+  .addCase('supports mocking inherited logger methods')
+  .args()
+  .mockImplementation(AppLogger, 'log', () => undefined)
+  .expectReturn('done')
+  .doneCase()
+  .doneSuite();
+
+void builder.run();


### PR DESCRIPTION
Update auto-mock resolver to include inherited prototype methods to enable mocking of logger-style dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-f48e0a50-42da-4d9d-9198-3bdbd0093f4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f48e0a50-42da-4d9d-9198-3bdbd0093f4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

