### PR TITLE
Current system bugs

### DIFF
--- a/lib/private/executers/test-case.executer.ts
+++ b/lib/private/executers/test-case.executer.ts
@@ -24,27 +24,13 @@ export class TestCaseExecuter<S extends Type, K extends MethodKeys<S>> {
     const spyInstances = this.applySelfSpies(cutInstance, spies);
 
     try {
-      const boundMethod = cutInstance[method].bind(cutInstance, ...args);
+      const boundMethod = cutInstance[method].bind(
+        cutInstance,
+        ...(args ?? []),
+      );
 
       if ('error' in expectation) {
-        // Test if the method throws an error
-        try {
-          const result = boundMethod();
-          if (result && typeof result.then === 'function') {
-            // Async method - wait for it to reject
-            await expect(result).rejects.toThrow();
-          } else {
-            // Sync method threw - this should not reach here if it throws properly
-            throw new Error(
-              'Expected method to throw an error, but it returned a value',
-            );
-          }
-        } catch (error) {
-          // Sync method threw - this is expected for sync throwing methods
-          expect(() => {
-            throw error;
-          }).toThrow();
-        }
+        await this.assertExpectedThrow(boundMethod, expectation.error);
       } else {
         try {
           let result = boundMethod();
@@ -65,6 +51,99 @@ export class TestCaseExecuter<S extends Type, K extends MethodKeys<S>> {
 
       this.restoreSpies(spyInstances);
     }
+  }
+
+  private async assertExpectedThrow(
+    boundMethod: () => unknown,
+    expectedError: unknown,
+  ): Promise<void> {
+    let result: unknown;
+
+    try {
+      result = boundMethod();
+    } catch (error) {
+      this.assertExpectedError(error, expectedError);
+      return;
+    }
+
+    if (this.isPromiseLike(result)) {
+      const outcome = await this.getPromiseOutcome(result);
+
+      if (outcome.status === 'resolved') {
+        throw new Error('Expected method to throw an error, but it resolved');
+      }
+
+      this.assertExpectedError(outcome.error, expectedError);
+      return;
+    }
+
+    throw new Error('Expected method to throw an error, but it returned a value');
+  }
+
+  private isPromiseLike(value: unknown): value is Promise<unknown> {
+    return Boolean(value) && typeof (value as Promise<unknown>).then === 'function';
+  }
+
+  private async getPromiseOutcome(
+    promise: Promise<unknown>,
+  ): Promise<
+    | { status: 'resolved'; value: unknown }
+    | { status: 'rejected'; error: unknown }
+  > {
+    return promise.then(
+      value => ({ status: 'resolved', value }),
+      error => ({ status: 'rejected', error }),
+    );
+  }
+
+  private assertExpectedError(actual: unknown, expected: unknown): void {
+    if (expected === undefined) {
+      expect(actual).toBeDefined();
+      return;
+    }
+
+    if (typeof expected === 'string') {
+      expect(this.getErrorMessage(actual)).toContain(expected);
+      return;
+    }
+
+    if (expected instanceof RegExp) {
+      expect(this.getErrorMessage(actual)).toMatch(expected);
+      return;
+    }
+
+    if (
+      expected &&
+      typeof expected === 'object' &&
+      'asymmetricMatch' in expected &&
+      typeof (expected as { asymmetricMatch?: unknown }).asymmetricMatch ===
+        'function'
+    ) {
+      expect(actual).toEqual(expected);
+      return;
+    }
+
+    if (typeof expected === 'function') {
+      expect(actual).toBeInstanceOf(expected as new (...args: any[]) => any);
+      return;
+    }
+
+    if (expected instanceof Error) {
+      expect(actual).toBeInstanceOf(
+        expected.constructor as new (...args: any[]) => Error,
+      );
+      return;
+    }
+
+    expect(actual).toEqual(expected);
+  }
+
+  private getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return String(error);
   }
 
   /**

--- a/lib/public/builders/case.builder.ts
+++ b/lib/public/builders/case.builder.ts
@@ -19,7 +19,7 @@ import {
 import { SuiteBuilder } from './suite.builder';
 
 export class CaseBuilder<S extends Provider, K extends MethodKeys<S>> {
-  private testArgs!: MethodParams<S, K>;
+  private testArgs: MethodParams<S, K> = [] as MethodParams<S, K>;
   private testMocks: MockConfiguration<S>[];
   private testModuleMocks: ModuleMockConfiguration[];
   private testExpectation!: Expectation<S, K>;

--- a/lib/public/builders/case.builder.ts
+++ b/lib/public/builders/case.builder.ts
@@ -19,7 +19,7 @@ import {
 import { SuiteBuilder } from './suite.builder';
 
 export class CaseBuilder<S extends Provider, K extends MethodKeys<S>> {
-  private testArgs: MethodParams<S, K> = [] as MethodParams<S, K>;
+  private testArgs: MethodParams<S, K>;
   private testMocks: MockConfiguration<S>[];
   private testModuleMocks: ModuleMockConfiguration[];
   private testExpectation!: Expectation<S, K>;
@@ -30,6 +30,7 @@ export class CaseBuilder<S extends Provider, K extends MethodKeys<S>> {
     private readonly caseStore: TestCaseStore<S, K>,
     private readonly description: string = 'No description',
   ) {
+    this.testArgs = [] as unknown as MethodParams<S, K>;
     this.testMocks = [];
     this.testModuleMocks = [];
     this.testSpies = [];


### PR DESCRIPTION
Refactor `expectThrow` to correctly fail when methods don't throw/reject and to validate thrown errors consistently, and initialize case arguments to an empty list to prevent undefined spread errors.

The previous `expectThrow` implementation could incorrectly pass tests where an error was expected but not thrown, particularly for asynchronous methods, and lacked comprehensive error validation. The `testArgs` fix addresses a potential runtime error when method arguments were not explicitly provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d242b6d-d294-4468-b745-f85991281497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d242b6d-d294-4468-b745-f85991281497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

